### PR TITLE
Set PATH for scripts executed from PHP

### DIFF
--- a/packaging/app-php-engines.spec
+++ b/packaging/app-php-engines.spec
@@ -82,6 +82,8 @@ install -D -m 0644 packaging/php_engines.conf %{buildroot}/etc/clearos/php_engin
 install -D -m 0755 packaging/php_wrapper %{buildroot}/usr/clearos/bin/php
 install -D -m 0644 packaging/rh-php56-php-fpm.php %{buildroot}/var/clearos/base/daemon/rh-php56-php-fpm.php
 install -D -m 0644 packaging/rh-php70-php-fpm.php %{buildroot}/var/clearos/base/daemon/rh-php70-php-fpm.php
+install -D -m 0644 packaging/www_path.conf %{buildroot}/etc/opt/rh/rh-php56/php-fpm.d/www_path.conf
+install -D -m 0644 packaging/www_path.conf %{buildroot}/etc/opt/rh/rh-php70/php-fpm.d/www_path.conf
 
 %post
 logger -p local6.notice -t installer 'app-php-engines - installing'
@@ -132,3 +134,5 @@ exit 0
 /usr/clearos/bin/php
 /var/clearos/base/daemon/rh-php56-php-fpm.php
 /var/clearos/base/daemon/rh-php70-php-fpm.php
+%config(noreplace) /etc/opt/rh/rh-php56/php-fpm.d/www_path.conf
+%config(noreplace) /etc/opt/rh/rh-php70/php-fpm.d/www_path.conf

--- a/packaging/www_path.conf
+++ b/packaging/www_path.conf
@@ -1,0 +1,4 @@
+[www]
+; Set the $PATH to this (default) pool, important when executing external commands (like php)
+; Adds ClearOS bin folder in addition of the standard folders
+env[PATH] = /usr/clearos/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin


### PR DESCRIPTION
Ensures that ClearOS path (as well as normal SO path) is accessible to programs executed from PHP